### PR TITLE
Added RedAlert.rb file to fix load issue

### DIFF
--- a/lib/RedAlert.rb
+++ b/lib/RedAlert.rb
@@ -1,0 +1,1 @@
+require_relative "./red_alert.rb"


### PR DESCRIPTION
Bundler expects the load file to be the same as the gem name. So this also would have worked:

```ruby
gem "RedAlert", require: "red_alert"
```

...but that's stupid.