### PR TITLE
Added map_action_buttons awesomeness

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,19 @@ Add the **RedAlert** gem to your Gemfile.
   end
 ```
 
+You can pass in symbols or strings and we'll build the buttons for you:
+
+```ruby
+rmq.app.alert title: "Hey!", actions: [ "Go ahead", :cancel, :delete ] do |button_tag|
+  case button_tag
+  when :cancel then puts "Canceled!"
+  when :delete then puts "Deleted!"
+  when "Go ahead" then puts "Going ahead!"
+  end
+end
+```
+
+
 You can even use the `make_button` helper to create custom UIAction buttons to add:
 ```ruby
   # Use custom UIAction buttons and add them

--- a/lib/project/button_templates.rb
+++ b/lib/project/button_templates.rb
@@ -24,17 +24,17 @@ module RubyMotionQuery
         [
           rmq.app.make_button(title: yes, tag: :yes, &block),
           rmq.app.make_button(title: no, tag: :no, &block),
-          rmq.app.make_button({title: cancel, tag: :cancel, style: :cancel}, &block)
+          rmq.app.make_button(title: cancel, tag: :cancel, style: :cancel, &block)
         ]
       when :ok_cancel
         [
-          rmq.app.make_button(ok, &block),
-          rmq.app.make_button({title: cancel, tag: :cancel, style: :cancel}, &block)
+          rmq.app.make_button(title: ok, &block),
+          rmq.app.make_button(title: cancel, tag: :cancel, style: :cancel, &block)
         ]
       when :delete_cancel
         [
-          rmq.app.make_button({title: delete, tag: :delete, style: :destructive}, &block),
-          rmq.app.make_button({title: cancel, tag: :cancel, style: :cancel}, &block)
+          rmq.app.make_button(title: delete, tag: :delete, style: :destructive, &block),
+          rmq.app.make_button(title: cancel, tag: :cancel, style: :cancel, &block)
         ]
       else
         []

--- a/lib/project/red_alert.rb
+++ b/lib/project/red_alert.rb
@@ -39,7 +39,7 @@ module RubyMotionQuery
         actions = []
         if opts[:actions] && opts[:actions].is_a?(Array) && opts[:actions].length > 0
           # caller has pre-defined actions
-          actions << opts[:actions]
+          actions << map_action_buttons(opts[:actions], &block)
         elsif opts[:actions] && opts[:actions].is_a?(Symbol)
           # caller wants a template
           actions << add_template_actions(opts[:actions], &block)
@@ -75,6 +75,31 @@ module RubyMotionQuery
       # @return [UIAlertAction]
       def make_button(opts={}, &block)
         AlertAction.new(opts, &block)
+      end
+
+      # Returns an array of action buttons based on the symbols you pass in.
+      # Usage Example:
+      #   rmq.app.alert title: "Hey!", actions: [ "Go ahead", :cancel, :delete ] do |button_tag|
+      #     puts "#{button_text} pressed"
+      #   end
+      def map_action_buttons(buttons, &block)
+        yes    = NSLocalizedString("Yes", nil)
+        no     = NSLocalizedString("No", nil)
+        cancel = NSLocalizedString("Cancel", nil)
+        ok     = NSLocalizedString("OK", nil)
+        delete = NSLocalizedString("Delete", nil)
+
+        buttons.map do |button|
+          case button
+          when :cancel  then make_button(title: cancel, tag: :cancel, style: :cancel, &block)
+          when :yes     then make_button(title: yes, tag: :yes, &block)
+          when :no      then make_button(title: no, tag: :no, &block)
+          when :ok      then make_button(title: ok, tag: :ok, &block)
+          when :delete  then make_button(title: delete, tag: :delete, style: :destructive, &block)
+          when String   then make_button(title: button, tag: button, &block)
+          else button
+          end
+        end
       end
 
     end # close eigenclass

--- a/spec/map_buttons_spec.rb
+++ b/spec/map_buttons_spec.rb
@@ -1,0 +1,88 @@
+describe "RedAlert.map_action_buttons" do
+
+  it "builds cancel button" do
+    test_array = [ :cancel ]
+    callback = ->(){}
+    subject = RubyMotionQuery::App.map_action_buttons(test_array, &callback )
+    subject.should.be.all {|s| s.is_a?(RubyMotionQuery::AlertAction) }
+    subject[0].title.should == "Cancel"
+    subject[0].tag.should == :cancel
+    subject[0].style.should == :cancel
+    subject[0].handler.should == callback
+  end
+
+  it "builds delete button" do
+    test_array = [ :delete ]
+    callback = ->(){}
+    subject = RubyMotionQuery::App.map_action_buttons(test_array, &callback )
+    subject.should.be.all {|s| s.is_a?(RubyMotionQuery::AlertAction) }
+    subject[0].title.should == "Delete"
+    subject[0].tag.should == :delete
+    subject[0].style.should == :destructive
+    subject[0].handler.should == callback
+  end
+
+  it "builds ok button" do
+    test_array = [ :ok ]
+    callback = ->(){}
+    subject = RubyMotionQuery::App.map_action_buttons(test_array, &callback )
+    subject.should.be.all {|s| s.is_a?(RubyMotionQuery::AlertAction) }
+    subject[0].title.should == "OK"
+    subject[0].tag.should == :ok
+    subject[0].style.should == :default
+    subject[0].handler.should == callback
+  end
+
+  it "builds yes button" do
+    test_array = [ :yes ]
+    callback = ->(){}
+    subject = RubyMotionQuery::App.map_action_buttons(test_array, &callback )
+    subject.should.be.all {|s| s.is_a?(RubyMotionQuery::AlertAction) }
+    subject[0].title.should == "Yes"
+    subject[0].tag.should == :yes
+    subject[0].style.should == :default
+    subject[0].handler.should == callback
+  end
+
+  it "builds no button" do
+    test_array = [ :no ]
+    callback = ->(){}
+    subject = RubyMotionQuery::App.map_action_buttons(test_array, &callback )
+    subject.should.be.all {|s| s.is_a?(RubyMotionQuery::AlertAction) }
+    subject[0].title.should == "No"
+    subject[0].tag.should == :no
+    subject[0].style.should == :default
+    subject[0].handler.should == callback
+  end
+
+
+  it "builds custom button" do
+    test_array = [ "Custom" ]
+    callback = ->(){}
+    subject = RubyMotionQuery::App.map_action_buttons(test_array, &callback )
+    subject.should.be.all {|s| s.is_a?(RubyMotionQuery::AlertAction) }
+    subject[0].title.should == "Custom"
+    subject[0].tag.should == "Custom"
+    subject[0].style.should == :default
+    subject[0].handler.should == callback
+  end
+
+  it "builds lots of buttons" do
+    callback = ->(){}
+    custom_button = RubyMotionQuery::AlertAction.new(title: "Custom", tag: "Custom", &callback)
+    test_array = [ "A", "B", "C", custom_button, :yes, :no, :ok, :delete, :cancel ]
+    subject = RubyMotionQuery::App.map_action_buttons(test_array, &callback )
+    subject.should.be.all {|s| s.is_a?(RubyMotionQuery::AlertAction) }
+    subject[0].title.should == "A"
+    subject[1].title.should == "B"
+    subject[2].title.should == "C"
+    subject[3].should.be == custom_button
+    subject[4].title.should == "Yes"
+    subject[5].title.should == "No"
+    subject[6].title.should == "OK"
+    subject[7].title.should == "Delete"
+    subject[8].title.should == "Cancel"
+  end
+
+
+end


### PR DESCRIPTION
Ref @kevinvangelder's issue #6 .

You can now do this:

```ruby
rmq.app.alert title: "My Title", actions: [ "Send Link", "Copy Link", :ok, :delete, :cancel ] do |button_tag|
  case button_tag
  when "Send Link" then puts "sending link!"
  when "Copy Link" then puts "copied link!"
  when :ok then puts "I don't know what that means!"
  when :cancel then puts "canceled!"
  else
  end
end
```

