### PR TITLE
ability to have text fields in your RedAlert alerts... works in iOS 7… and 8. enjoy :)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    RedAlert (1.1)
+    RedAlert (1.1.1)
       ruby_motion_query (>= 1.3.4)
 
 GEM
   remote: https://rubygems.org/
   specs:
     rake (10.4.2)
-    ruby_motion_query (1.3.5)
+    ruby_motion_query (1.5.0)
 
 PLATFORMS
   ruby

--- a/lib/project/alert_controller_provider.rb
+++ b/lib/project/alert_controller_provider.rb
@@ -22,7 +22,11 @@ module RubyMotionQuery
 
         # convert the callback
         handler = lambda do |action|
-          alert_action.handler.call(alert_action.tag) unless alert_action.handler.nil?
+          if !@opts[:textfields] && !alert_action.handler.nil?
+            alert_action.handler.call(alert_action.tag)
+          elsif @opts[:textfields] && !alert_action.handler.nil?
+            alert_action.handler.call(alert_action.tag, @alert_controller.textFields.map {|t| t.text})
+          end
         end if alert_action.handler
 
         # create teh action
@@ -30,6 +34,16 @@ module RubyMotionQuery
 
         # add it to the UIAlertController
         @alert_controller.addAction action
+      end
+
+      textfields = @opts[:textfields]
+      if(textfields)
+        textfields.each do |t|
+          @alert_controller.addTextFieldWithConfigurationHandler -> (textField) {
+            textField.placeholder = t[:placeholder] || "Enter some text"
+            textField.secureTextEntry = t[:secure] || false
+          }
+        end
       end
 
       self

--- a/red_alert.gemspec
+++ b/red_alert.gemspec
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 $:.push File.expand_path('../lib', __FILE__)
-VERSION = "1.1"
+VERSION = "1.1.1"
 
 Gem::Specification.new do |spec|
   spec.name          = "RedAlert"

--- a/spec/alert_controller_provider_spec.rb
+++ b/spec/alert_controller_provider_spec.rb
@@ -18,6 +18,17 @@ describe "RubyMotionQuery" do
       Proc.new { @p.build([]) }.should.raise(ArgumentError)
     end
 
+    describe "alert controller with 1 text field" do
+
+      before do
+        @p.build [@ok], title: "hi", style: :alert, textfields: [placeholder: "hi"]
+      end
+
+      it "should have one text field" do
+        @p.alert_controller.textFields.size.should == 1
+      end
+    end
+
     describe "alert controller with ok button" do
 
       before do

--- a/spec/alert_view_provider_spec.rb
+++ b/spec/alert_view_provider_spec.rb
@@ -1,6 +1,5 @@
 describe "RubyMotionQuery" do
   describe "AlertViewProvider" do
-
     before do
       @p      = RubyMotionQuery::AlertViewProvider.new
       @ok     = RubyMotionQuery::AlertAction.new(title: "OK", tag: :ok, style: :default)
@@ -14,6 +13,30 @@ describe "RubyMotionQuery" do
 
     it "should prevent empty actions" do
       Proc.new { @p.build([]) }.should.raise(ArgumentError)
+    end
+
+    describe "alert view with one text field" do
+
+      before do
+        @p.build [@ok], title: "hi", style: :alert, textfields: [placeholder: "hi"]
+      end
+
+      it "should have one text field" do
+        @p.alert_view.textFieldAtIndex(0).should != nil
+      end
+
+    end
+
+    describe "alert view with two text field" do
+
+      before do
+        @p.build [@ok], title: "hi", style: :alert, textfields: [placeholder: "hi"]
+      end
+
+      it "should have one text field" do
+        @p.alert_view.textFieldAtIndex(0).should != nil
+      end
+
     end
 
     describe "alert view with ok button" do

--- a/spec/red_alert_spec.rb
+++ b/spec/red_alert_spec.rb
@@ -45,6 +45,12 @@ describe 'RedAlert' do
       @provider.alert_controller.message.should == "hello"
     end
 
+    # it "gets the text back if a textfield is sent..." do
+    #   rmq.app.alert(message: "hello", textfields: [placeholder: "insert text"]) do |action, text|
+    # ???
+    #   end
+    # end
+
   end
 
   describe "UIActionSheet Hosted" do


### PR DESCRIPTION
yo all.

I saw #8 and I needed this feature. And while we use Bubblewrap, I didn't want to, when I already have a dedicated library for alerts (RedAlert.) Also, BW didn't seem to support iOS 8 fully. And I don't want the warning.

So I wrote this for ya. I tried to share the API as much as possible between 7 and 8, but truth is the style is a bit different... anyway I'm happy with what I did. There's 2 tests I added as well. Couldn't figure out how to test if the text is returned, but I hand tested it. But don't take my word for it.

iOS 7

```ruby
# textfield_style may also be "secure" which is simply a password field, or omitted for just a single plain text field
# in iOS7 there is no way to add more than 2 textfields...
# tho since I shared API, "placeholder" is optional, but actually having elements in "textfields" is not. change to your liking. it is just designed to keep the API similar between the 7 and 8
rmq.app.alert(message: "Plz login", textfield_style: :login, textfields: [placeholder: "User", placeholder: "Password"]) do |action, text|
# you know how to use action.
# "text" will be an array of textfield values.
p text
end
```

iOS8

```ruby
# textfield_style is not used here
# "secure" is optional
# "placeholder" is also optional, but something must be in the array or fields won't be created. placeholder is recommended, as nothing else will do anything... also helpful to user.
rmq.app.alert(message: "Plz login", textfields: [{placeholder: "User"}, {placeholder: "Password", secure: true}]) do |action, text|
# same as above. text is array of field values.
p text
end
```

Thanks, and good luck! - @jsilverMDX

edit: I forgot to say. Happy 4th of July! :fireworks: