### PR TITLE
Allow user to force a sheet's message to be empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ nbproject
 .idea
 .dat*.*
 Gemfile.lock
+.ruby-version

--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -45,6 +45,13 @@ class MainController < UIViewController
           end
         end
 
+        # Sheet with no message
+        acs.append(UIButton, :alert_controller_five).on(:tap) do
+          rmq.app.alert(message: nil, style: :sheet, actions: :yes_no_cancel ) do |action_type|
+            puts "you clicked #{action_type}"
+          end
+        end
+
         ##############################
         #  Field examples
         ##############################

--- a/app/stylesheets/main_stylesheet.rb
+++ b/app/stylesheets/main_stylesheet.rb
@@ -68,6 +68,11 @@ class MainStylesheet < ApplicationStylesheet
     st.text = "Title and :sheet Style"
   end
 
+  def alert_controller_five st
+    basic_button(st)
+    st.text = ":sheet Style with no message"
+  end
+
   def alert_controller_fields_one st
     basic_button(st)
     st.text = "Fields :input Style"

--- a/lib/project/red_alert.rb
+++ b/lib/project/red_alert.rb
@@ -19,7 +19,13 @@ module RubyMotionQuery
         # ------------------------------------
         opts           = {message: opts} if opts.is_a? String
         opts           = {style: :alert, animated: true, show_now: true}.merge(opts)
-        opts[:message] = opts[:message] ? opts[:message].to_s : NSLocalizedString("Alert!", nil)
+
+        opts[:message] = if opts.has_key?(:message)
+          opts[:message].nil? ? nil : opts[:message].to_s
+        else
+          NSLocalizedString("Alert!", nil)
+        end
+
         opts[:style]   = VALID_STYLES.include?(opts[:style]) ? opts[:style] : :alert
         opts[:fields]  = opts[:style] == :custom && opts[:fields] ? opts[:fields] : {text: {placeholder: ''}}
         api            = rmq.device.ios_at_least?(8) ? :modern : :deprecated

--- a/spec/red_alert_spec.rb
+++ b/spec/red_alert_spec.rb
@@ -46,6 +46,10 @@ describe 'RedAlert' do
       @provider.alert_controller.message.should == "hello"
     end
 
+    it "allows an empty message" do
+      @provider = rmq.app.alert(message: nil, show_now: false, animated: false)
+      @provider.alert_controller.message.should == nil
+    end
   end
 
   describe "UIActionSheet Hosted" do


### PR DESCRIPTION
Apple's action sheet docs show sheets with no titles or messages. This PR supports this by allowing you to explicitly pass a `nil` for the message.