### PR TITLE
Handle modal ViewController on rmq.view_controller

### DIFF
--- a/lib/project/alert_controller_provider.rb
+++ b/lib/project/alert_controller_provider.rb
@@ -79,7 +79,8 @@ module RubyMotionQuery
     end
 
     def show
-      rmq.view_controller.presentViewController(@alert_controller, animated: @opts[:animated], completion: nil)
+      view_controller = rmq.view_controller.childModalViewController || rmq.view_controller
+      view_controller.presentViewController(@alert_controller, animated: @opts[:animated], completion: nil)
     end
 
   end


### PR DESCRIPTION
rmq.view_controller doesn't handle modal VCs which will result in #22.
This commit changes the behavior of `show` to also work on modal VCs.
Fixes #22