### PR TITLE
Adds the ability to pass :text to an :input

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: objective-c
+osx_image: xcode7.2
 before_install:
   - (ruby --version)
   - sudo chown -R travis ~/Library/RubyMotion

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ before_install:
 gemfile:
   - Gemfile
 script:
-  - /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/usr/bin/simctl create air com.apple.CoreSimulator.SimDeviceType.iPad-Air com.apple.CoreSimulator.SimRuntime.iOS-8-1
+  # - /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/usr/bin/simctl create air com.apple.CoreSimulator.SimDeviceType.iPad-Air com.apple.CoreSimulator.SimRuntime.iOS-8-1
   - bundle install
   - bundle exec rake clean
   - bundle exec rake spec
-  - bundle exec rake spec device_name=air
+  # - bundle exec rake spec device_name=air

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Add the **RedAlert** gem to your Gemfile.
     puts "you entered '#{fields[:login].text}' as the login and '#{fields[:password].text}' as the password"
   end
 
+  # Pre-fill text into an input field
+  rmq.app.alert(title: "Text Field", message: "My style is :input", style: :input, text: "Some Text", placeholder: "Some Placeholder") do |action_type, fields|
+    puts "you entered '#{fields[:text].text}'"
+  end
+
+
   # Add input fields with settings for placeholder text, whether the field is secure, and the keyboard type by setting the style to :custom
   rmq.app.alert(title: "Text Field", message: "My style is :custom", style: :custom, fields:
                {phone: {placeholder: 'Phone', keyboard_type: :phone_pad},

--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -70,29 +70,36 @@ class MainController < UIViewController
           end
         end
 
-        # Text field example with :secure style.
+        # Text field example with :input style and text pre-set
         acs.append(UIButton, :alert_controller_fields_three).on(:tap) do
+          rmq.app.alert(title: "Text Field", message: "My style is :input", style: :input, text: "Some Text", placeholder: "Some Placeholder") do |action_type, fields|
+            puts "you entered '#{fields[:text].text}'"
+          end
+        end
+
+        # Text field example with :secure style.
+        acs.append(UIButton, :alert_controller_fields_four).on(:tap) do
           rmq.app.alert(title: "Text Field", message: "My style is :secure", style: :secure) do |action_type, fields|
             puts "you entered '#{fields[:text].text}'"
           end
         end
 
         # Text field example with :login style.
-        acs.append(UIButton, :alert_controller_fields_four).on(:tap) do
+        acs.append(UIButton, :alert_controller_fields_five).on(:tap) do
           rmq.app.alert(title: "Text Field", message: "My style is :login", style: :login) do |action_type, fields|
             puts "you entered '#{fields[:login].text}' as the login and '#{fields[:password].text}' as the password"
           end
         end
 
         # Text field example with :change_password style.
-        acs.append(UIButton, :alert_controller_fields_five).on(:tap) do
+        acs.append(UIButton, :alert_controller_fields_six).on(:tap) do
           rmq.app.alert(title: "Text Field", message: "My style is :change_password", style: :change_password) do |action_type, fields|
             puts "you entered '#{fields[:current_password].text}' as the current password and '#{fields[:new_password].text}' as the new password"
           end
         end
 
         # Text field example with :custom style.
-        acs.append(UIButton, :alert_controller_fields_six).on(:tap) do
+        acs.append(UIButton, :alert_controller_fields_seven).on(:tap) do
           rmq.app.alert(title: "Text Field", message: "My style is :custom", style: :custom, fields:
                        {phone: {placeholder: 'Phone', keyboard_type: :phone_pad},
                         email: {placeholder: 'Email', secure: false, keyboard_type: :email_address}}) do |action_type, fields|

--- a/app/stylesheets/main_stylesheet.rb
+++ b/app/stylesheets/main_stylesheet.rb
@@ -85,20 +85,25 @@ class MainStylesheet < ApplicationStylesheet
 
   def alert_controller_fields_three st
     basic_button(st)
-    st.text = "Fields :secure Style"
+    st.text = "Fields :input w/ text"
   end
 
   def alert_controller_fields_four st
     basic_button(st)
-    st.text = "Fields :login Style"
+    st.text = "Fields :secure Style"
   end
 
   def alert_controller_fields_five st
     basic_button(st)
-    st.text = "Fields :change_password Style"
+    st.text = "Fields :login Style"
   end
 
   def alert_controller_fields_six st
+    basic_button(st)
+    st.text = "Fields :change_password Style"
+  end
+
+  def alert_controller_fields_seven st
     basic_button(st)
     st.text = "Fields :custom Style"
   end

--- a/lib/project/alert_controller_provider.rb
+++ b/lib/project/alert_controller_provider.rb
@@ -20,6 +20,7 @@ module RubyMotionQuery
         fieldset[:fields].each_with_index do |field, index|
           handler = lambda do |text_field|
             text_field.placeholder = field.placeholder if field.placeholder.is_a? String
+            text_field.text = field.text if field.text.is_a? String
             text_field.secureTextEntry = field.secure_text_entry if field.secure_text_entry.is_a? String
             text_field.keyboardType = RubyMotionQuery::Stylers::KEYBOARD_TYPES[field.keyboard_type]
           end

--- a/lib/project/alert_field.rb
+++ b/lib/project/alert_field.rb
@@ -3,6 +3,7 @@ module RubyMotionQuery
 
     attr_accessor :keyboard_type
     attr_accessor :placeholder
+    attr_accessor :text
     attr_accessor :secure_text_entry
     attr_accessor :name
 
@@ -12,6 +13,7 @@ module RubyMotionQuery
       @name               = name.is_a?(Symbol) ? name : name.strip.gsub(/\s+/,'_').to_sym
       @keyboard_type      = RubyMotionQuery::Stylers::KEYBOARD_TYPES.has_key?(opts[:keyboard_type]) ? opts[:keyboard_type] : :default
       @placeholder        = opts[:placeholder] || ''
+      @text               = opts[:text] || ''
       @secure_text_entry  = opts[:secure_text_entry] || false
     end
   end

--- a/lib/project/alert_view_provider.rb
+++ b/lib/project/alert_view_provider.rb
@@ -34,6 +34,7 @@ module RubyMotionQuery
         fieldset[:fields].each_with_index do |field, index|
           text_field = @alert_view.textFieldAtIndex index
           text_field.placeholder = field.placeholder
+          text_field.text = field.text
           text_field.secureTextEntry = field.secure_text_entry
           text_field.keyboardType = RubyMotionQuery::Stylers::KEYBOARD_TYPES[field.keyboard_type]
           @text_fields[field.name] = text_field

--- a/lib/project/field_templates.rb
+++ b/lib/project/field_templates.rb
@@ -19,7 +19,7 @@ module RubyMotionQuery
           fieldset[:alert_view_style] = UIAlertViewStylePlainTextInput
           fieldset[:fields] =
           [
-            rmq.app.make_field(:text, keyboard_type: :default, secure_text_entry: false, placeholder: opts.fetch(:placeholder,''))
+            rmq.app.make_field(:text, keyboard_type: :default, secure_text_entry: false, placeholder: opts.fetch(:placeholder,''), text: opts.fetch(:text,''))
           ]
         when :secure
           fieldset[:alert_view_style] = UIAlertViewStyleSecureTextInput

--- a/spec/alert_field_spec.rb
+++ b/spec/alert_field_spec.rb
@@ -50,6 +50,18 @@ describe "AlertField" do
 
   end
 
+  describe "#text" do
+
+    it "should use the text option if provided" do
+      af.new(:name, text: "Gant").text.should == "Gant"
+    end
+
+    it "should set the text to an empty stringif not provided" do
+      af.new(:name).text.should == ""
+    end
+
+  end
+
   describe "#secure_text_entry" do
 
     it "should default to false" do

--- a/spec/alert_view_provider_spec.rb
+++ b/spec/alert_view_provider_spec.rb
@@ -4,6 +4,7 @@ describe "RubyMotionQuery" do
     before do
       @p      = RubyMotionQuery::AlertViewProvider.new
       @fieldset = {alert_view_style: UIAlertViewStylePlainTextInput, fields: [RubyMotionQuery::AlertField.new(:text)]}
+      @placeholder_fieldset = {alert_view_style: UIAlertViewStylePlainTextInput, fields: [RubyMotionQuery::AlertField.new(:text, {placeholder: "placeholder", text: "text"})]}
       @ok     = RubyMotionQuery::AlertAction.new(title: "OK", tag: :ok, style: :default)
       @cancel = RubyMotionQuery::AlertAction.new(title: "Cancel", tag: :cancel, style: :cancel)
       @boom   = RubyMotionQuery::AlertAction.new(title: "Boom!", tag: :boom, style: :destructive)
@@ -77,6 +78,26 @@ describe "RubyMotionQuery" do
 
       it 'has a text field with an empty placeholder' do
         @p.alert_view.textFieldAtIndex(0).placeholder.should == nil
+      end
+
+      it 'has a text field with an empty text' do
+        @p.alert_view.textFieldAtIndex(0).text.should == ""
+      end
+
+    end
+
+    shared "an alert view with a placeholder" do
+
+      it 'has a placeholder' do
+        @p.alert_view.textFieldAtIndex(0).placeholder.should == "placeholder"
+      end
+
+    end
+
+    shared "an alert view with text pre-set" do
+
+      it 'has text' do
+        @p.alert_view.textFieldAtIndex(0).text.should == "text"
       end
 
     end
@@ -156,6 +177,16 @@ describe "RubyMotionQuery" do
         behaves_like "an alert view with a destructive button"
         behaves_like "an alert view with one field"
 
+      end
+
+      describe "an alert view with placeholder and text" do
+
+        before do
+          @p.build [@boom], @placeholder_fieldset, title: "title"
+        end
+
+        behaves_like "an alert view with a placeholder"
+        behaves_like "an alert view with text pre-set"
       end
     end
 


### PR DESCRIPTION
Allows the user to pre-fill the input box with text. Only works for `:input` style. Can be expanded for `:secure`, `:password`, etc. if needed in the future.

Usage: 

```ruby
rmq.app.alert(title: "Text Field", message: "My style is :input", style: :input, text: "Some Text", placeholder: "Some Placeholder") do |action_type, fields|
  puts "you entered '#{fields[:text].text}'"
end
```
