### PR TITLE
Fixes crash when presenting a :sheet on iPad from UIBarButtonItem

### DIFF
--- a/lib/project/alert_controller_provider.rb
+++ b/lib/project/alert_controller_provider.rb
@@ -60,8 +60,8 @@ module RubyMotionQuery
           @alert_controller.popoverPresentationController.barButtonItem = source
         else
           @alert_controller.popoverPresentationController.sourceView = source
+          @alert_controller.popoverPresentationController.sourceRect = source.bounds
         end
-        @alert_controller.popoverPresentationController.sourceRect = source.bounds
 
         if @opts[:arrow_direction]
           directions = @opts[:arrow_direction]


### PR DESCRIPTION
```bash
2016-03-16 10:23:02.505 App-Dev[30273:5438583] alert_controller_provider.rb:64:in `build:': undefined method `bounds' for #<UIBarButtonItem:0x119c62e10> (NoMethodError)
	from red_alert.rb:87:in `alert:'
	from profile_screen.rb:94:in `tapped_more:'
2016-03-16 10:23:02.524 App-Dev[30273:5438583] *** Terminating app due to uncaught exception 'NoMethodError', reason: 'alert_controller_provider.rb:64:in `build:': undefined method `bounds' for #<UIBarButtonItem:0x119c62e10> (NoMethodError)
```