### PR TITLE
Move gem version into its own file

### DIFF
--- a/lib/project/version.rb
+++ b/lib/project/version.rb
@@ -1,0 +1,3 @@
+module RedAlert
+  VERSION = "1.5.1"
+end

--- a/red_alert.gemspec
+++ b/red_alert.gemspec
@@ -1,10 +1,11 @@
 # -*- encoding: utf-8 -*-
 $:.push File.expand_path('../lib', __FILE__)
-VERSION = "1.5"
+
+require File.expand_path('../lib/project/version', __FILE__)
 
 Gem::Specification.new do |spec|
   spec.name          = "RedAlert"
-  spec.version       = VERSION
+  spec.version       = RedAlert::VERSION
   spec.authors       = ["Gant Laborde"]
   spec.email         = ["GantMan@gmail.com"]
   spec.description   = "RMQ Plugin adds efficient and dynamic alerts/sheets for RubyMotion Apps on iOS 7 & 8"
@@ -20,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'ruby_motion_query', '>= 1.3.4'
-  spec.add_development_dependency "rake"
+  spec.add_runtime_dependency "ruby_motion_query", ">= 1.3.4"
+  spec.add_development_dependency "rake", "~> 0"
 end


### PR DESCRIPTION
So that global `VERSION` in the gemspec file doesn't conflict with other gems.

Please push to rubygems after you merge...

```bash
$ gem build red_alert.gemspec
$ gem push RedAlert-1.5.1.gem
```

Thanks!